### PR TITLE
Return the gorelic.Agent from InitNewRelicAgent so other people can use it

### DIFF
--- a/gorelic/gorelic.go
+++ b/gorelic/gorelic.go
@@ -29,10 +29,10 @@ func Handler() echo.MiddlewareFunc {
 
 // InitNewRelicAgent initializes a new gorelic agent for usage in Handler
 func InitNewRelicAgent(license string, appname string, verbose bool) (*gorelic.Agent, error) {
-	agent = gorelic.NewAgent()
 	if license == "" {
-		return agent, fmt.Errorf("Please specify a NewRelic license")
+		return gorelic.NewAgent(), fmt.Errorf("Please specify a NewRelic license")
 	}
+	agent = gorelic.NewAgent()
 
 	agent.NewrelicLicense = license
 	agent.NewrelicName = appname

--- a/gorelic/gorelic.go
+++ b/gorelic/gorelic.go
@@ -28,12 +28,11 @@ func Handler() echo.MiddlewareFunc {
 }
 
 // InitNewRelicAgent initializes a new gorelic agent for usage in Handler
-func InitNewRelicAgent(license string, appname string, verbose bool) error {
-	if license == "" {
-		return fmt.Errorf("Please specify a NewRelic license")
-	}
-
+func InitNewRelicAgent(license string, appname string, verbose bool) (*gorelic.Agent, error) {
 	agent = gorelic.NewAgent()
+	if license == "" {
+		return agent, fmt.Errorf("Please specify a NewRelic license")
+	}
 
 	agent.NewrelicLicense = license
 	agent.NewrelicName = appname
@@ -43,5 +42,5 @@ func InitNewRelicAgent(license string, appname string, verbose bool) error {
 
 	agent.Run()
 
-	return nil
+	return agent, nil
 }


### PR DESCRIPTION
This changes the return signature of InitNewRelicAgent to return the Agent so it can be held onto and used to log other metrics elsewhere in the app.
