### PR TITLE
Update sessions to echo version 2

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo"
+	"github.com/labstack/echo/engine/standard"
 )
 
 const (
@@ -62,14 +63,14 @@ type Session interface {
 
 func Sessions(name string, store Store) echo.MiddlewareFunc {
 	return func(h echo.HandlerFunc) echo.HandlerFunc {
-		return func(c *echo.Context) error {
+		return func(c echo.Context) error {
 			s := &session{
 				name,
-				c.Request(),
+				c.Request().(*standard.Request).Request,
 				store,
 				nil,
 				false,
-				c.Response().Writer(),
+				c.Response().(*standard.Response).ResponseWriter,
 			}
 
 			c.Set(DefaultKey, s)
@@ -154,7 +155,7 @@ func (s *session) Written() bool {
 }
 
 // shortcut to get session
-func Default(c *echo.Context) Session {
+func Default(c echo.Context) Session {
 	session := c.Get(DefaultKey)
 	if session == nil {
 		return nil


### PR DESCRIPTION
This only works with the standard engine because fasthttp doesn't use http.Response or http.Request. The other change is that c is no longer a pointer.

I tested this with the code I had from before upgrading to version 2.

Closes #5 
